### PR TITLE
adds prefixes in svg file

### DIFF
--- a/img/svg-logo/enny-logo.svg
+++ b/img/svg-logo/enny-logo.svg
@@ -2,7 +2,7 @@
 	 viewBox="0 0 187.7 167.9" style="enable-background:new 0 0 187.7 167.9;" xml:space="preserve">
 <style type="text/css">
   .st0{stroke:#f2f2f2;stroke-width:2;stroke-miterlimit:5;}
-  
+
   #svg-logo {
   stroke-dasharray: 900;
   stroke-dashoffset: 900;
@@ -12,9 +12,25 @@
   animation: draw 4.5s forwards linear;
   fill: #4f4f4f;
   transition: all ease;
-} 
-  
+}
 
+
+@-webkit-keyframes draw {
+  0% {
+    stroke-dashoffset: 900;
+  }
+  80% {
+    stroke-dashoffset:0;
+  }
+  80% {
+    stroke-dashoffset:0;
+    fill: #4f4f4f;
+  }
+  100% {
+    stroke-dashoffset:0;
+    fill: #f2f2f2;
+  }
+}
 @keyframes draw {
   0% {
     stroke-dashoffset: 900;
@@ -31,12 +47,12 @@
     fill: #f2f2f2;
   }
 }
-  
-
-  
 
 
-  
+
+
+
+
 </style>
 <path id="XMLID_4_" class="st0" d="M152,79.1l-0.2,0c16.7-6.1,26.9-20,26.9-35.4c0-12.5-5-21.9-13.2-28.1
 	c-9.9-8-23.1-11.6-43.6-11.6c-9.8,0-19.8,0.1-27.8,0c-8.7-0.1-17.4,0-27.2,0c-20.5,0-33.7,3.5-43.6,11.6C14.9,21.8,10,31.2,10,43.7


### PR DESCRIPTION
Because the css got moved inside of the svg file from the scss, the auto-prefixing was no longer happening. Merge these changes and your svg will work.
